### PR TITLE
dryrun_diff: add HTML breakdown

### DIFF
--- a/manheim_c7n_tools/runner.py
+++ b/manheim_c7n_tools/runner.py
@@ -328,6 +328,7 @@ class DryRunDiffStep(BaseStep):
         logger.info('Nothing to do during normal run.')
 
     def dryrun(self):
+        logger.info('doing something here')
         DryRunDiffer(self.config).run(diff_against='origin/master')
 
     @staticmethod

--- a/manheim_c7n_tools/tests/test_runner.py
+++ b/manheim_c7n_tools/tests/test_runner.py
@@ -56,7 +56,9 @@ class FakeConfig:
 class StepTester(object):
 
     def setup(self):
-        self.m_conf = Mock(spec_set=ManheimConfig)
+        # in order to supplant __getattr__ calls
+        self.m_conf = Mock(spec=ManheimConfig)
+        self.m_conf.account_id = '01234567890'
 
 
 class TestPolicygenStep(StepTester):

--- a/templates/diffreport.j2
+++ b/templates/diffreport.j2
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/5.0.0/normalize.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/milligram/1.3.0/milligram.css">
+    <title>Report: {{ account_name }}</title>
+  </head>
+  <body style="padding: 20px;">
+    <h2>Difference Report</h2>
+    <h3>Account: {{ account_name }}</h3>
+    <p>
+      This document is a break-down of all of the resources that are affected by the changes made within a certain policy.
+    </p>
+    <p>
+      Each section of this document is broken down by policy name, the region in which the policy was ran against, and the list of all of the affected resources.
+    </p>
+    <p>
+      You might find that the list of affected resources are highlighted in certain colors, with a marker placed against them. The table outlined below will tell you what each color and marker represents:
+    </p>
+    <table>
+      <th>Color</th>
+      <th>Marker</th>
+      <th>Explaination</th>
+      <th>Example</th>
+      <tr>
+        <td>Green</td>
+        <td>+</td>
+        <td>This outlines a resource that has been added by changes under this PR against the last run on master</td>
+        <td style="background-color: #98e8736b;padding-left: 10px;padding-right: 10px;"><code style="background: none;">+ arn://hellotherewowthisisanarn.ohcool.amazing</code></td>
+      </tr>
+      <tr>
+        <td>Red</td>
+        <td>-</td>
+        <td>This outlines a resource that has been removed by changes under this PR against the last run on master</td>
+        <td style="background-color: #e873736b;padding-left: 10px;padding-right: 10px;"><code style="background: none;">- arn://hellotherewowthisisanarn.ohcool.amazing</code></td>
+      </tr>
+      <tr>
+        <td>Grey</td>
+        <td>=</td>
+        <td>This outlines a resource that has remained in changes under this PR against the last run on master</td>
+        <td style="background-color: #fafafa;padding-left: 10px;padding-right: 10px;"><code style="background: none;">= arn://hellotherewowthisisanarn.ohcool.amazing</code></td>
+      </tr>
+    </table>
+    {% for policy, entry in entries.items() -%}
+    <h4> {{ policy }} </h4>
+    <ul>
+      {% for region, item in entry.items() -%}
+      <li>
+        <strong>{{ region }}</strong>
+        <code style="background-color: #98e8736b;">+ {{ item.total_add }}</code>
+        <code style="background-color: #e873736b;">- {{ item.total_remove }}</code>
+        <code style="background-color: #fafafa;">= {{ item.total_untouch }}</code>
+        <div style="padding: 15px 15px 0 15px;">
+          <table>
+            {% for r in item.resources -%}
+            {% if r.type == 'added' -%}
+            <tr style="background-color: #98e8736b;"><td style="padding-left: 10px;padding-right: 10px;"><code style="background: none;"> + {{ r.id }} </code></td></tr>
+            {% elif r.type == 'removed' -%}
+            <tr style="background-color: #e873736b;"><td style="padding-left: 10px;padding-right: 10px;"><code style="background: none;"> - {{ r.id }} </code></td></tr>
+            {% elif r.type == 'unchanged' -%}
+            <tr style="background-color: #fafafa;"><td style="padding-left: 10px;padding-right: 10px;"><code style="background: none;"> = {{ r.id }} </code></td></tr>
+            {%- endif %}
+            {%- endfor %}
+          </table>
+        </div>
+      </li>
+      {%- endfor %}
+    </ul>
+    {%- endfor %}
+  </body>
+</html>


### PR DESCRIPTION
## Description

This PR adds a HTML rendered document that details a breakdown of affected policies between a dryrun and the last live run of manhiem. 

The current Markdown document only describes the 'high-level' difference count between both the dryrun and the last live run. This is useful for comments on a PR, as the report is concise and outlines the overall effect changes to a given policy, however this is not enough information if you wish to know which resources have been affected by policy changes.

We feel that the inclusion of a detailed HTML report of changes will provide an extra layer of confidence during a review before any policy changes are merged. The mechanism of how to expose this document is entirely up to the user; they could upload it to S3 as a static HTML webpage, integrate it with Slack, email the report, etc.

Below is a brief snapshot of a report - with some information redacted:

![Screenshot 2020-04-28 at 11 03 18](https://user-images.githubusercontent.com/14886082/80475054-35198a80-8940-11ea-98dc-a8dffafd00c6.png)

## Testing Done

Similar to the markdown generation, we log whenever the function is called - however no additional unit testing has been done.

We have modified the mock generation of the BaseStep Class to stub out `self.config.account_id` in order to supplant the mockers issues with `__getattr__`.

## Important Notes

* The [milligram html framework was used for the HTML reports](https://milligram.io/)

## Contributor License Agreement

Required for external contributors.

By submitting this work for inclusion in manheim-c7n-tools, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the manheim-c7n-tools project (Apache v2).
* My contribution may perpetually be included in and distributed with manheim-c7n-tools; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of manheim-c7n-tools's license.
* I have the legal power and rights to agree to these terms.
